### PR TITLE
don't treat ALTER ROLE SET like ALTER ROLE

### DIFF
--- a/src/aiven_gatekeeper.c
+++ b/src/aiven_gatekeeper.c
@@ -131,7 +131,6 @@ gatekeeper_checks(PROCESS_UTILITY_PARAMS)
     switch (stmt->type)
     {
     case T_AlterRoleStmt: // ALTER ROLE
-    case T_AlterRoleSetStmt:
         alterRoleStmt = (AlterRoleStmt *)stmt;
         // check if we are altering with superuser
 


### PR DESCRIPTION
The two statements have different structures and ALTER ROLE SET does not have the `options` member,
leading to an unsafe cast:

```c
typedef struct AlterRoleStmt
{
	NodeTag		type;
	RoleSpec   *role;			/* role */
	List	   *options;		/* List of DefElem nodes */
	int			action;			/* +1 = add members, -1 = drop members */
} AlterRoleStmt;

typedef struct AlterRoleSetStmt
{
	NodeTag		type;
	RoleSpec   *role;			/* role */
	char	   *database;		/* database name, or NULL */
	VariableSetStmt *setstmt;	/* SET or RESET subcommand */
} AlterRoleSetStmt;
```

