### PR TITLE
Workflow to build the extension

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build
+
+permissions: read-all
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '**'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    strategy:
+      max-parallel: 3
+      matrix:
+        pg-version: [10, 11, 12, 13, 14]
+    steps:
+      - id: install
+        run: |
+          # Remove preinstalled Postgres because this will conflict with the version we actually want.
+          sudo apt-get remove -u postgresql\*
+          # Setup the Postgres repositories
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main 14" > /etc/apt/sources.list.d/pgdg.list'
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo apt-get update
+          # Install build deps
+          sudo apt-get install -y postgresql-server-dev-${{ matrix.pg-version }}
+      - id: checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - id: make
+        run: make
+


### PR DESCRIPTION
This patch introduces a `build.yml` workflow that builds the extension on Postgres 10 to 14. Right now it just runs a `make` to make (🥁 ) sure that the extension builds without errors for all the different Postgres versions that we support.