### PR TITLE
Remove PGDG key import from workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ jobs:
           sudo apt-get remove -u postgresql\*
           # Setup the Postgres repositories
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main 14" > /etc/apt/sources.list.d/pgdg.list'
-          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt-get update
           # Install build deps
           sudo apt-get install -y postgresql-server-dev-${{ matrix.pg-version }}


### PR DESCRIPTION
This patch removes the import of the GPG key for the Postgres repository. It looks like this not needed because all the GitHub workers come with the `pgdg-keyring` package installed, which drops the right key in `/etc/apt/trusted.gpg.d`.

This is good because `wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add - ` was a pretty sketchy thing to do without key verification 😎 