### PR TITLE
Change Postgres repository URL to https

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           # Remove preinstalled Postgres because this will conflict with the version we actually want.
           sudo apt-get remove -u postgresql\*
           # Setup the Postgres repositories
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main 14" > /etc/apt/sources.list.d/pgdg.list'
+          sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           sudo apt-get update
           # Install build deps
           sudo apt-get install -y postgresql-server-dev-${{ matrix.pg-version }}


### PR DESCRIPTION
This patch changes the package repository base url to `https://`. Also remove the trailing `14` from the entry - I am not sure why that is in there or why it is needed.