### PR TITLE
Fixes #1 - Compile warning: ISO C90 forbids mixed declarations and code

### DIFF
--- a/src/aiven_gatekeeper.c
+++ b/src/aiven_gatekeeper.c
@@ -148,6 +148,18 @@ allow_grant_role(Oid role_oid)
 static void
 gatekeeper_checks(PROCESS_UTILITY_PARAMS)
 {
+    Node *stmt;
+    CopyStmt *copyStmt;
+    CreateRoleStmt *createRoleStmt;
+    AlterRoleStmt *alterRoleStmt;
+    GrantRoleStmt *grantRoleStmt;
+    ListCell *option;
+    DefElem *defel;
+    List *addroleto;
+    ListCell *grantRoleCell;
+    AccessPriv *priv;
+    Oid roleoid;
+
     /* if the agent is disabled, skip all checks */
     if (!pg_security_agent_enabled)
     {
@@ -163,19 +175,7 @@ gatekeeper_checks(PROCESS_UTILITY_PARAMS)
 
     /* get the utilty statment from the planner
      * https://github.com/postgres/postgres/blob/24d2b2680a8d0e01b30ce8a41c4eb3b47aca5031/src/backend/tcop/utility.c#L575
-     */
-    Node *stmt;
-    CopyStmt *copyStmt;
-    CreateRoleStmt *createRoleStmt;
-    AlterRoleStmt *alterRoleStmt;
-    GrantRoleStmt *grantRoleStmt;
-    ListCell *option;
-    DefElem *defel;
-    List *addroleto;
-    ListCell *grantRoleCell;
-    AccessPriv *priv;
-    Oid roleoid;
-    
+     */    
     stmt = pstmt->utilityStmt;
 
     /* switch between the types to see if we care about this stmt */


### PR DESCRIPTION
This patch silences the following compile warning:

```
src/aiven_gatekeeper.c: In function ‘gatekeeper_checks’:
src/aiven_gatekeeper.c:1[6](https://github.com/aiven/aiven-pg-security/runs/6780308057?check_suite_focus=true#step:4:7)[7](https://github.com/aiven/aiven-pg-security/runs/6780308057?check_suite_focus=true#step:4:8):5: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
  167 |     Node *stmt = pstmt->utilityStmt;
      |     ^~~~
```
