### PR TITLE
Additional checks

### DIFF
--- a/src/aiven_gatekeeper.c
+++ b/src/aiven_gatekeeper.c
@@ -56,6 +56,7 @@ static const char *reserved_func_names[] = {"pg_read_file",
                                             "pg_read_binary_file",
                                             "pg_read_binary_file_all",
                                             "pg_read_binary_file_off_len",
+                                            "pg_reload_conf",
                                             "be_lo_import",
                                             "be_lo_export",
                                             "be_lo_import_with_oid"};


### PR DESCRIPTION
# About this change - What it does

Adds a list of reserved functions and a hook to perform a security check before calling those functions. These functions would allow bypassing some of the existing security checks in `ProcessUtility_hook`. 

Also resolves: #4 

# Why this way

It would have been nice to use the [needs_fmgr_hook](https://github.com/taminomara/psql-hooks/blob/master/Detailed.md#needs_fmgr_hook) and [fmgr_hook](https://github.com/taminomara/psql-hooks/blob/master/Detailed.md#fmgr_hook) however these [are bypassed for builtin functions](https://doxygen.postgresql.org/fmgr_8c.html#aeb6e6365746570268bc476da26f5605e).

The description of the [object_access_hook](https://doxygen.postgresql.org/objectaccess_8h.html#a7638c33e464e7a526124be366f5ecbfc)  does indicate that this is meant for these security type checks anyway, so it is a good candidate.
> /*
    * Hook on object accesses.  This is intended as infrastructure for security
    * and logging plugins.
    */
 object_access_hook_type object_access_hook = NULL;

The preloading of Oids for the disallowed functions is aimed at providing a performant solution that does not require expensive lookups in the builtins struct every time a function is accessed. There are some other attempts at performance like checking if Oid is outside the range we have of stored Oids.

This is a little strict, like disabling `GRANT EXECUTE ON FUNCTION ...` access to the disallow-listed functions. If we did leave the ability to grant execute on these functions, it would be pretty trivial to bypass the security agent.
