### PR TITLE
Check if CurrentResourceOwner is null

### DIFF
--- a/src/aiven_gatekeeper.c
+++ b/src/aiven_gatekeeper.c
@@ -26,6 +26,7 @@
 #include "utils/guc.h"
 #include "utils/fmgrtab.h"
 #include "utils/lsyscache.h"
+#include "utils/resowner.h"
 #include "utils/varlena.h"
 #include "nodes/nodes.h"
 #include "access/sysattr.h"
@@ -131,7 +132,7 @@ is_elevated(void)
     /* short circuit if the current and session user are the same
      * saves on a slightly more expensive role fetch
      */
-    if (currentUserId == sessionUserId)
+    if (currentUserId == sessionUserId || CurrentResourceOwner == NULL)
     {
         return false;
     }


### PR DESCRIPTION
# About this change - What it does
Checks that the `CurrentResourceOwner` is not NULL before trying to check if the calling user is a superuser.

Resolves: 501

# Why this way
When reloading pg config from file, the `CurrentResourceOwner` is NULL. Calling `superuser_arg` or `superuser` in this context is unsafe and leads to a segfault.
