### PR TITLE
Fix ALTER ROLE segfault

### DIFF
--- a/src/aiven_gatekeeper.c
+++ b/src/aiven_gatekeeper.c
@@ -290,7 +290,7 @@ gatekeeper_checks(PROCESS_UTILITY_PARAMS)
         alterRoleStmt = (AlterRoleStmt *)stmt;
 
         // check we aren't altering a reserved role (existing superuser)
-        roleoid = get_role_oid(alterRoleStmt->role->rolename, true);
+        roleoid = get_rolespec_oid(alterRoleStmt->role, true);
         result = allow_grant_or_alter_role(roleoid);
         if (result != NULL)
             elog(ERROR, "%s", result);


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

`ALTER ROLE role_specification` causes segfaults if `role_specification` is one of `CURRENT_ROLE`, `CURRENT_USER`, `SESSION_USER`.

We need to dispatch `alterRoleStmt->role->roletype` first before we can use `alterRoleStmt->role->rolename`, which is only filled for `roletype` set to `ROLESPEC_CSTRING`, so we just use `get_rolespec_oid` instead of `get_role_oid` for that.

<!-- Provide the issue number below if it exists. -->
Resolves: BF-1691

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

`get_role_oid` needs a valid cstring (i.e., not `NULL`) as `rolname` argument, but `alterRoleStmt->role->rolename` might be `NULL` in the cases described above. `get_rolespec_oid` is designed for `RoleSpec` nodes and does the `RoleSpecType`  dispatch for us.