### PR TITLE
Check if we have a user in is_elevated

### DIFF
--- a/src/aiven_gatekeeper.c
+++ b/src/aiven_gatekeeper.c
@@ -132,10 +132,20 @@ is_elevated(void)
      * we can say that we are in an elevated context.
      */
 
-    Oid currentUserId = GetUserId();
-    Oid sessionUserId = GetSessionUserId();
-
+    int secContext = 0;
+    Oid currentUserId = InvalidOid;
+    Oid sessionUserId;
     bool is_superuser;
+    
+    /* when starting up we can't call GetUserId() because
+     * that requires a valid user to be set. Check manually
+     * and bail out if that is the case.
+     */
+    GetUserIdAndSecContext(&currentUserId, &secContext);
+    if (!OidIsValid(currentUserId))
+        return false;
+
+    sessionUserId = GetSessionUserId();
 
     /* short circuit if the current and session user are the same
      * saves on a slightly more expensive role fetch


### PR DESCRIPTION
On start-up when we define the properties, `is_elevated` gets called even if we don't have a current user. This violates the assert in `GetUserId()` and errors out in builds that are compiled with assertions enabled. The logic still works with invalid OIDs but it's better to handle that case explicitly.

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

